### PR TITLE
Debug the layout shift

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -62,7 +62,7 @@
   h5,
   h6 {
     font-family: var(--font-geist);
-    @apply tracking-tight text-black dark:text-white font-bold lg:w-2/4;
+    @apply tracking-tight text-black dark:text-white font-bold lg:w-3/4;
   }
 
   /* Code typography */
@@ -98,7 +98,7 @@
 
   p {
     @apply text-base md:text-lg;
-    @apply tracking-tight text-black dark:text-white lg:w-2/4;
+    @apply tracking-tight text-black dark:text-white lg:w-3/4;
   }
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -126,7 +126,7 @@ export default async function RootLayout({
       lang="en"
       dir="ltr"
       suppressHydrationWarning
-      className={`${inter.variable} ${geist.variable} ${geistMono.variable}`}
+      className={`${inter.variable} ${geist.variable} ${geistMono.variable} pb-18`}
     >
       <head>
         <script
@@ -136,7 +136,7 @@ export default async function RootLayout({
       </head>
       <body className="w-full h-full flex-center bg-white dark:bg-black">
         <LayoutWrapper jsonLdData={jsonLd}>
-          <main className="w-[90vw] md:w-[92.5vw] lg:w-[95vw]">
+          <main className="w-[90vw] md:w-[92.5vw] lg:w-[95vw] my-12">
             <Toaster />
             <Analytics />
             {children}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -126,7 +126,7 @@ export default async function RootLayout({
       lang="en"
       dir="ltr"
       suppressHydrationWarning
-      className={`${inter.variable} ${geist.variable} ${geistMono.variable} pb-18`}
+      className={`${inter.variable} ${geist.variable} ${geistMono.variable}`}
     >
       <head>
         <script
@@ -136,7 +136,7 @@ export default async function RootLayout({
       </head>
       <body className="w-full h-full flex-center bg-white dark:bg-black">
         <LayoutWrapper jsonLdData={jsonLd}>
-          <main className="w-[90vw] md:w-[92.5vw] lg:w-[95vw] my-12">
+          <main className="w-[90vw] md:w-[92.5vw] lg:w-[95vw]">
             <Toaster />
             <Analytics />
             {children}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,15 +17,15 @@ const Home: React.FC = () => {
     <main className="flex fl flex-col gap-18">
       <section className="w-full flex flex-col gap-4">
         <aside>
-          <h4>Hello, I&apos;m Ege!</h4>
-          <h1>I&apos;m an entrepreneur.</h1>
+          <h5>Hello, I&apos;m Ege!</h5>
+          <h1>I&apos;m a builder.</h1>
         </aside>
         <p>
           I’m a young entrepreneur building minimalist productivity tools. I
           craft focused software that empowers creators to stay organized,
           efficient, and inspired.
         </p>
-        <section className="w-full grid gap-4">
+        <section className="w-full grid md:flex gap-4">
           <Link href="/#explore">
             <button className="btn-2 w-full md:w-auto">Explore my work</button>
           </Link>
@@ -62,7 +62,7 @@ const Home: React.FC = () => {
       </section>
       <section className="w-full flex flex-col gap-4">
         <h3>My projects</h3>
-        <section className="grid gap-4 lg:grid-cols-3">
+        <section className="grid gap-4 lg:grid-cols-3" id="explore">
           {projects.map((project) => {
             return (
               <Link href={project.link || "/"} key={project.id}>
@@ -88,9 +88,11 @@ const Home: React.FC = () => {
       </section>
       <section className="w-full flex flex-col gap-4">
         <h2>Testimonials</h2>
-        <Testimonials />
+        <div className="w-full">
+          <Testimonials />
+        </div>
       </section>
-      <section className="w-full flex flex-col gap-4">
+      <section className="w-full flex flex-col gap-4" id="get-in-touch">
         <h2>Get in touch</h2>
         <Contact />
       </section>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,7 +14,7 @@ import Contact from "@/components/landing/Contact";
 
 const Home: React.FC = () => {
   return (
-    <main className="flex fl flex-col gap-18">
+    <main className="flex w-full flex-col gap-18">
       <section className="w-full flex flex-col gap-4">
         <aside>
           <h5>Hello, I&apos;m Ege!</h5>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -28,7 +28,7 @@ const Footer: React.FC = () => {
                     href="mailto:hello@egeuysal.com"
                     className="footer-text"
                   >
-                    Contact us
+                    Contact
                   </Link>
                 </li>
               </ul>
@@ -49,7 +49,7 @@ const Footer: React.FC = () => {
                   <Globe size={iconSize} className="text-black dark:text-white" />
                 </Link>
                 <Link
-                  href="https://github.com/egeuysall/portfolio"
+                  href="https://github.com/egeuysall"
                   target="_blank"
                   rel="noopener noreferrer"
                   aria-label="GitHub"

--- a/components/landing/Testimonials.tsx
+++ b/components/landing/Testimonials.tsx
@@ -7,7 +7,7 @@ const secondRow = reviews.slice(reviews.length / 2);
 
 export default function MarqueeDemo() {
   return (
-    <div className="relative flex w-screen flex-col items-center justify-center overflow-hidden">
+    <div className="relative flex w-full flex-col items-center justify-center overflow-hidden">
       <Marquee className="[--duration:5]">
         {firstRow.map((review) => (
           <div className="px-2" key={review.username}>


### PR DESCRIPTION
This pull request introduces updates to the layout, typography, and component structure of the portfolio website. The changes focus on improving responsiveness, accessibility, and content presentation across various sections. Below is a categorized summary of the most important updates:

### Layout and Responsiveness Improvements:
* Updated the `main` and `Testimonials` sections in `app/page.tsx` to use `w-full` for better responsiveness. Additionally, the "My projects" section now includes an `id` attribute for navigation (`#explore`). [[1]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L17-R28) [[2]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L65-R65) [[3]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R91-R95)
* Adjusted the `Testimonials` marquee container in `components/landing/Testimonials.tsx` to use `w-full` instead of `w-screen` for better alignment with the rest of the layout.

### Typography Updates:
* Changed the typography styles in `app/globals.css` for headings (`h5`, `h6`) and paragraphs (`p`) to increase their width (`lg:w-3/4` instead of `lg:w-2/4`) for improved readability. [[1]](diffhunk://#diff-79e0914d9fee5ca4432bdb002a24d700d31b5577265f4de3f90d5c292b9f1392L65-R65) [[2]](diffhunk://#diff-79e0914d9fee5ca4432bdb002a24d700d31b5577265f4de3f90d5c292b9f1392L101-R101)
* Updated the heading levels in `app/page.tsx` to better reflect content hierarchy, such as replacing `<h4>` with `<h5>` for the introduction.

### Content and Accessibility Enhancements:
* Updated the "Contact us" link text in the footer to "Contact" for conciseness in `components/Footer.tsx`.
* Modified the GitHub link in the footer to point to the user's main GitHub profile instead of a specific repository.