### PR TITLE
Update times

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -8,27 +8,27 @@
 
 <url>
   <loc>https://www.egeuysal.com/</loc>
-  <lastmod>2025-04-26T19:54:17+00:00</lastmod>
+  <lastmod>2025-04-27T00:35:16+00:00</lastmod>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://www.egeuysal.com/blog</loc>
-  <lastmod>2025-04-26T19:54:17+00:00</lastmod>
+  <lastmod>2025-04-27T00:35:16+00:00</lastmod>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://www.egeuysal.com/blog/second-brain</loc>
-  <lastmod>2025-04-26T19:54:17+00:00</lastmod>
+  <lastmod>2025-04-27T00:35:16+00:00</lastmod>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://www.egeuysal.com/blog/astraui-release</loc>
-  <lastmod>2025-04-26T19:54:17+00:00</lastmod>
+  <lastmod>2025-04-27T00:35:16+00:00</lastmod>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://www.egeuysal.com/blog/links-release</loc>
-  <lastmod>2025-04-26T19:54:17+00:00</lastmod>
+  <lastmod>2025-04-27T00:35:16+00:00</lastmod>
   <priority>0.80</priority>
 </url>
 


### PR DESCRIPTION
This pull request updates the `lastmod` timestamps in the `public/sitemap.xml` file to reflect a new modification date for multiple URLs.

Details of the change:

* [`public/sitemap.xml`](diffhunk://#diff-bd4a35c26151469a9eaebf7c16024e40ceb05d52afe4aa08904081be72a40cafL11-R31): Updated the `lastmod` field for all listed URLs to `2025-04-27T00:35:16+00:00`, replacing the previous timestamp of `2025-04-26T19:54:17+00:00`.